### PR TITLE
Including mac installation instruction in the website

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -16,7 +16,7 @@ layout: default
 
 ---
 
-[macOS homebrew tap](https://github.com/CVC4/homebrew-cvc4)
+[macOS homebrew tap](/mac.html)
 
 ---
 

--- a/mac.md
+++ b/mac.md
@@ -1,0 +1,13 @@
+---
+layout: default
+---
+
+# Homebrew tap for CVC4
+[Homebrew](https://brew.sh/) is a package manager for macOS.
+To install CVC4 using Homebrew, use the following commands in your terminal:
+```
+$ brew tap cvc4/cvc4
+$ brew install cvc4/cvc4/cvc4
+```
+
+For more details and advanced options, please visit [this](https://github.com/CVC4/homebrew-cvc4) page.


### PR DESCRIPTION
This PR copies the basic installation instructions for macOS from the github repo of the homebrew tap to cvc4's website.